### PR TITLE
Use proper boundaries to deal with the first token

### DIFF
--- a/scripts/generate_cards/generate.py
+++ b/scripts/generate_cards/generate.py
@@ -52,7 +52,7 @@ def tokenize(text: str, lang: str):
     if lang in icu_words:
         icu_words[lang].setText(text)
         boundaries = list(icu_words[lang])
-        return [text[i:j] for i, j in zip(boundaries, boundaries[1:])]
+        return [text[i:j] for i, j in zip([0] + boundaries, boundaries)]
 
     # any other language, just use spaces
     return text.split()


### PR DESCRIPTION
The first word segment from ICU does not have the starting index 0 so it needs to be added explicitly