### PR TITLE
Clozegen improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 backend/static/
 # dotenv file
 .env
+
+# sentence files
+scripts/links.csv
+scripts/sentences.csv
+# output data
+scripts/universal_cards.*

--- a/scripts/generate_cards/README.md
+++ b/scripts/generate_cards/README.md
@@ -13,12 +13,12 @@ You need Python3.6 or later. Download the sentence and links file mentioned abov
 files, `sentences.csv` and `links.csv`.
 
 ## ICU component
-To perform word segmentation on some languages the [ICU library](https://site.icu-project.org/) is used.
+To perform word segmentation the [ICU library](https://site.icu-project.org/) is used.
 This requires ICU to be installed first.
 The exact installation procedure depends on the system, you'll have to look at the site and be ready to search
 on the internet.
 
-However, here is how I installed it on macOS Catalina:
+However, here is how I installed it on __macOS Catalina__:
 
 * `brew install intltool icu4c gettext` to install the packages using Brew, may be already installed
 * `export ICU_VERSION=67` to set the library version
@@ -26,7 +26,7 @@ However, here is how I installed it on macOS Catalina:
 * `export PKG_CONFIG_PATH="/usr/local/opt/icu4c/lib/pkgconfig"` to allow pyICU build to find the package
 * `export PATH=/usr/local/opt/icu4c/bin:$PATH` to allow pyICU build to run icu-config
 
-On Debian/Ubuntu:
+On __Debian/Ubuntu__ (used in the Docker image for the whole project):
 
 * `apt-get update && apt-get install libicu-dev gettext`
 

--- a/scripts/generate_cards/requirements.txt
+++ b/scripts/generate_cards/requirements.txt
@@ -1,3 +1,1 @@
-chop==1.0
-tinysegmenter==0.4
 pyicu==2.5

--- a/scripts/initial_setup.sh
+++ b/scripts/initial_setup.sh
@@ -1,6 +1,6 @@
 # this script can create an initial DB and populate it
 # is supposed to run in the same container of the app
-apt-get update && apt-get install -y libicu-dev pkg-config wget
+apt-get update && apt-get install -y libicu-dev pkg-config wget postgresql-client
 pip3 install -r /scripts/generate_cards/requirements.txt
 wget https://downloads.tatoeba.org/exports/sentences.tar.bz2
 tar -xvjf sentences.tar.bz2

--- a/scripts/populate_db/populate_db/iso693_3.py
+++ b/scripts/populate_db/populate_db/iso693_3.py
@@ -366,4 +366,6 @@ ISO_693_3 = {
     'jpa': 'Jewish Palestinian Aramaic',
     'phn': 'Phoenician',
     'rel': 'Rendille',
+    'iii': 'Nuosu',
+    'drt': 'Drents',
 }

--- a/scripts/populate_db/populate_db/populate.py
+++ b/scripts/populate_db/populate_db/populate.py
@@ -44,8 +44,8 @@ async def main(jsonl_file: str):
                 card['original_txt'],
                 card['resulting_tokens'],
             ))
-        except KeyError:
-            print(f'Error processing a row: {line}')
+        except KeyError as ke:
+            print(f'Error processing a row: {line}: {ke}')
         if len(pending) > 2000:
             async with conn.transaction():
                 # much slower but allows to specify the target columns:


### PR DESCRIPTION
By switching to ICU only to split words Chinese is handled properly without loosing parts of the sentence (close issue #34) and now space is part of tokens and is not "injected" by the frontend closing issue #33 

This makes the tokenization more consistent across languages and extends it to languages like Shanghainese that were not tokened properly before.

Investigating this issue found additional problems regarding punctuation to be stripped, now the script uses all punctuation symbols from the Unicode metadata.

RTL UI is implemented as well, using the list from Tatoeba source, as suggested in #28  